### PR TITLE
8 as part of the critical path detection identify blocking models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.4"
+version = "1.1.5"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.7"
+version = "1.1.8"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.5"
+version = "1.1.6"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.0.0"
+version = "1.1.3"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtmon"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
     { name="John Small", email="johnsmall407@gmail.com" }
 ]

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "1.1.3"
+__manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__init__.py
+++ b/src/dbtmon/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 __manifest_version__ = "v1"

--- a/src/dbtmon/__main__.py
+++ b/src/dbtmon/__main__.py
@@ -23,6 +23,44 @@ parser.add_argument(
     default=0.025,
     help="Minimum wait time before checking stdin (default: 0.025)",
 )
+parser.add_argument(
+    "--dbtmon-project-dir",
+    type=str,
+    default=None,
+    help="Path to the dbtmon project directory (default: None)",
+)
+
+# Blocking Thread Detection
+parser.add_argument(
+    "--disable-blocking-thread-detection",
+    action="store_true",
+    help="Disable blocking thread detection (default: False)",
+)
+parser.add_argument(
+    "--minimum-blocking-time",
+    type=float,
+    default=60.0,
+    help="Minimum time (in seconds) for a thread to be considered blocking (default: 60.0)",
+)
+parser.add_argument(
+    "--blocking-minimum-job-size",
+    type=int,
+    default=0,
+    help="Minimum number of jobs in flight to trigger blocking detection (default: 0)",
+)
+
+# dbtmon Manifest Controls
+parser.add_argument(
+    "--disable-dbtmon-manifest",
+    action="store_true",
+    help="Disable generation and usage of the dbtmon manifest (default: False)",
+)
+parser.add_argument(
+    "--dbtmon-manifest-path",
+    type=str,
+    default="target/dbtmon_manifest.json",
+    help="Path to the dbtmon manifest file (default: target/dbtmon_manifest.json)",
+)
 
 # Provide a list of CLI options to export
 OPTIONS: list[str] = []

--- a/src/dbtmon/__main__.py
+++ b/src/dbtmon/__main__.py
@@ -48,11 +48,21 @@ def cli():
         subprocess.run(["__dbtmonpipe__"] + sys.argv[1:])
         return
 
+    # TODO: Improve this flow so that CLI args can be passed from outside the config file
+
     dbtmon_args = []
+    # Handle custom project directory settings
+    try:
+        directory_index = sys.argv.index("--project-dir")
+        dbtmon_args = ["--dbtmon_project_dir", sys.argv[directory_index+1]]
+    except ValueError:
+        # project-dir is not specified in the args
+        pass
+
     dbtmon_config = Path.home() / ".dbt" / "dbtmon.yml"
     if dbtmon_config.exists():
         with open(dbtmon_config, "r") as f:
-            config: dict = yaml.safe_load(f)
+            config: dict = yaml.safe_load(f) or {}
 
         for key, value in config.items():
             if key not in OPTIONS:
@@ -65,7 +75,7 @@ def cli():
             dbtmon_args.append(f"--{key}")
             if value is None:
                 continue
-            
+
             if isinstance(value, Collection):
                 dbtmon_args.extend(value)
             else:

--- a/src/dbtmon/__main__.py
+++ b/src/dbtmon/__main__.py
@@ -124,6 +124,8 @@ def cli():
             else:
                 dbtmon_args.append(value)
 
+            dbtmon_args = [str(arg) for arg in dbtmon_args]
+
     try:
         # Run `dbt` with user args, pipe stdout into __dbtmonpipe__
         dbt = subprocess.Popen(

--- a/src/dbtmon/__main__.py
+++ b/src/dbtmon/__main__.py
@@ -7,10 +7,15 @@ import yaml
 from pathlib import Path
 
 from dbtmon.monitor import DBTMonitor
-
+from dbtmon import __version__
 
 # Define command line arguments
 parser = argparse.ArgumentParser(description="dbt monitor")
+parser.add_argument(
+    "--version",
+    action="version",
+    version=__version__
+)
 parser.add_argument(
     "--polling-rate",
     type=float,

--- a/src/dbtmon/__main__.py
+++ b/src/dbtmon/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import subprocess
 import sys
+from typing import Collection
 import yaml
 from pathlib import Path
 
@@ -62,7 +63,12 @@ def cli():
                 continue
 
             dbtmon_args.append(f"--{key}")
-            if value is not None:
+            if value is None:
+                continue
+            
+            if isinstance(value, Collection):
+                dbtmon_args.extend(value)
+            else:
                 dbtmon_args.append(value)
 
     try:

--- a/src/dbtmon/config.py
+++ b/src/dbtmon/config.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+@dataclass
+class DBTMonConfig:
+    # Runtime parameters
+    polling_rate: float = 0.2
+    minimum_wait: float = 0.025
+    dbtmon_project_dir: str = None
+
+    # Blocking Thread Detection
+    disable_blocking_thread_detection: bool = False
+    minimum_blocking_time: float = 60.0
+    blocking_minimum_job_size: int = 0
+
+    # dbtmon Manifest Controls
+    disable_dbtmon_manifest: bool = False
+    # This path can be relative, in which case it's resolved from the project_dir
+    dbtmon_manifest_path: str = "target/dbtmon_manifest.json"
+
+    # TODO: add a read from file method
+    # CLI overwrites config file args by default
+    # Optional argument would specify that we should not read from the config file
+
+    # TODO: Add a classmethod that generates the default Config object as a config file in the
+    # user's Home directory

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -381,11 +381,12 @@ class DBTMonitor:
             manifest = self.build_manifest()
 
             # Calculate Critical Path
+            print("[dbtmon] Critical Path:")
             dag = self.get_dbt_dag(dbtmon_manifest=manifest)
             critical_path = nx.dag_longest_path(dag, weight="runtime", default_weight=0)
             for node in critical_path:
                 *_, model_name = node.split(".", maxsplit=2)
-                runtime = manifest.get(model_name, {}).get("runtime")
+                runtime = manifest["nodes"].get(model_name, {}).get("runtime")
                 if runtime is None:
                     timestamp = "N/A"
                 else:

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -27,7 +27,7 @@ class DBTThread:
     message: str
     status: str
     started_at: float
-    runtime: float = None
+    runtime: float = 0.0
     exit_code: int = 0
     min_concurrent_threads: int = 999
     max_concurrent_threads: int = 0

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -35,7 +35,8 @@ class DBTThread:
 
     @property
     def model_name(self) -> str:
-        *_, model_name = self.message.strip(".").split()
+        *_, schema_model_name = self.message.strip(".").split()
+        _, model_name = schema_model_name.split(".")
         return model_name
 
     @staticmethod

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -346,9 +346,9 @@ class DBTMonitor:
             # Find the entry in dbtmon_manifest for edge weighting
             # dbtmon stores this by name, not the fully qualified name
             # int__my_model vs my_project.model.int__my_model
-            dbtmon_data = dbtmon_manifest.get(node_data.get("name"), {})
-            if dbtmon_data:
-                print(f"Found {node_name} in manifest!")
+            search_name = node_data.get("name")
+            dbtmon_data = dbtmon_manifest.get(search_name, {})
+            print(f"{node_name=}, {search_name=}, found={bool(dbtmon_data)}")
 
             for dependency in node_data.get("depends_on", {}).get("nodes", []):
                 dag.add_edge(dependency, node_name, **dbtmon_data)

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -320,7 +320,7 @@ class DBTMonitor:
 
         return manifest
     
-    def get_dbt_dag(self, dbtmon_manifest: dict = None) -> nx.DiGraph:
+    def get_dbt_dag(self, dbtmon_manifest: dict[str, dict] = None) -> nx.DiGraph:
         dbtmon_manifest = dbtmon_manifest or {}
         try:
             project_dir = self.get_project_dir()
@@ -347,8 +347,7 @@ class DBTMonitor:
             # dbtmon stores this by name, not the fully qualified name
             # int__my_model vs my_project.model.int__my_model
             search_name = node_data.get("name")
-            dbtmon_data = dbtmon_manifest.get(search_name, {})
-            print(f"{node_name=}, {search_name=}, found={bool(dbtmon_data)}")
+            dbtmon_data = dbtmon_manifest["nodes"].get(search_name, {})
 
             for dependency in node_data.get("depends_on", {}).get("nodes", []):
                 dag.add_edge(dependency, node_name, **dbtmon_data)

--- a/src/dbtmon/monitor.py
+++ b/src/dbtmon/monitor.py
@@ -102,7 +102,7 @@ class DBTThread:
             "exit_code": self.exit_code,
             "min_concurrent_threads": self.min_concurrent_threads,
             "max_concurrent_threads": self.max_concurrent_threads,
-            "blocking_time": self.get_raw_blocking_time()
+            "blocking_time": self.get_raw_blocking_time() if self.min_concurrent_threads == 1 else 0.0
         }
 
 
@@ -347,6 +347,8 @@ class DBTMonitor:
             # dbtmon stores this by name, not the fully qualified name
             # int__my_model vs my_project.model.int__my_model
             dbtmon_data = dbtmon_manifest.get(node_data.get("name"), {})
+            if dbtmon_data:
+                print(f"Found {node_name} in manifest!")
 
             for dependency in node_data.get("depends_on", {}).get("nodes", []):
                 dag.add_edge(dependency, node_name, **dbtmon_data)


### PR DESCRIPTION
New in version 1.1.9 (stable):
- Blocking model detection: dbtmon now prints information after runs describing the models that ran with no other models running ("blocking" models). This is configurable with CLI & config file args
- Critical path detection: dbtmon now prints the critical path through the DAG. Currently, it always prints the full critical path, but future changes will modify this to print only for the current run's models.
- dbtmon manifest file: dbtmon saves model runtimes and metadata to a new file `dbtmon_manifest.json` which is placed next to `dbt_manifest.json`.
- Config file parser: Added a new class-based config file parser which will provide scaffolding for future utility.

Bugfixes:
- Fixed bugs with CLI argument parsing & config files